### PR TITLE
fix: Add name to Text example

### DIFF
--- a/example/components/Text.tsx
+++ b/example/components/Text.tsx
@@ -61,7 +61,14 @@ export const Text: React.FC<TextProps> = ({
   const [x, y] = toSvgBasis([userX, userY])
 
   return (
-    <SvgText ref={textRef} x={x} y={y} {...props} onPointerDown={startDragging}>
+    <SvgText
+      name="text"
+      ref={textRef}
+      x={x}
+      y={y}
+      {...props}
+      onPointerDown={startDragging}
+    >
       {children}
     </SvgText>
   )


### PR DESCRIPTION
`useDraggable` hook requires a `name` or it will log an error in the console.