### PR TITLE
fix: Non draggable Circle throws error

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
     [0.7, 0.5],
     [0.3, 0.2],
   ])
-  const [circle1Pos, setCircle1Pos] = useState<Coord>([-0.3333, 0.3333])
+  const [circle1Pos] = useState<Coord>([-0.3333, 0.3333])
   const [circle2Pos, setCircle2Pos] = useState<Coord>([0.2, -0.5])
   const [circle3Pos, setCircle3Pos] = useState<Coord>([-0.5, -0.3001])
 
@@ -64,7 +64,7 @@ const App: React.FC = () => {
             I can be dragged but I am limited to the visible area
           </Text>
           <Polygon pos={polygonPos} onChangePos={setPolygonPos} />
-          <Circle pos={circle1Pos} onChangePos={setCircle1Pos} r={5} />
+          <Circle pos={circle1Pos} r={5} />
           <DraggableCircle
             pos={circle2Pos}
             onChangePos={setCircle2Pos}

--- a/example/components/Circle.tsx
+++ b/example/components/Circle.tsx
@@ -30,10 +30,6 @@ interface CircleProps extends React.SVGProps<SVGCircleElement> {
    * A coordinate pair [x, y] that represents the middle of the circle.
    */
   readonly pos: Coord
-  /**
-   * Callback with new coordinates when they were changed.
-   */
-  readonly onChangePos: (pos: Coord) => void
 }
 
 export const Circle: React.FC<CircleProps> = ({ pos, ...circleProps }) => {
@@ -144,7 +140,7 @@ export const FastDraggableCircle: React.FC<DraggableCircleProps> = ({
       const [x0, y0] = toSvgBasis(pos)
       const updatePosition: DraggableHandler = (
         { vector: [tx, ty] },
-        ended
+        ended,
       ) => {
         const newSvgPos: Coord = clampCoord([x0 + tx, y0 + ty])
         circleEl.setAttribute('cx', String(newSvgPos[0]))


### PR DESCRIPTION
The example Circle that was not actually draggable throws an error.

> Warning: Unknown event handler property `onChangePos`. It will be ignored.