### PR TITLE
feat!: compute width/height internally

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -49,10 +49,10 @@ const App: React.FC = () => {
       </p>
 
       <Foundation
-        width={640}
-        height={480}
         userBasis={USER_BASIS}
         style={{
+          width: '640px',
+          height: '480px',
           border: '1px solid deepskyblue',
         }}
       >

--- a/example/components/Circle.tsx
+++ b/example/components/Circle.tsx
@@ -80,7 +80,11 @@ export const DraggableCircle: React.FC<DraggableCircleProps> = ({
 }) => {
   const { toSvgBasis, toUserBasis } = useContext(FoundationContext)
   const { clampCoord } = useContext(LinerContext)
+
   const [svgPos, setSvgPos] = useState(toSvgBasis(pos))
+  useEffect(() => {
+    setSvgPos(toSvgBasis(pos))
+  }, [pos, toSvgBasis])
 
   const { subscribe, unsubscribe, start: drag } = useDraggable()
 
@@ -97,7 +101,7 @@ export const DraggableCircle: React.FC<DraggableCircleProps> = ({
     return () => {
       unsubscribe()
     }
-  }, [pos])
+  }, [pos, toSvgBasis, toUserBasis])
 
   const [cx, cy] = svgPos
 
@@ -154,7 +158,7 @@ export const FastDraggableCircle: React.FC<DraggableCircleProps> = ({
         unsubscribe()
       }
     }
-  }, [pos])
+  }, [pos, toSvgBasis, toUserBasis])
 
   const [cx, cy] = toSvgBasis(pos)
 

--- a/example/components/Polygon.tsx
+++ b/example/components/Polygon.tsx
@@ -45,6 +45,9 @@ export const Polygon: React.FC<PolygonProps> = ({ pos, onChangePos }) => {
   const { clampCoord, clampCoordArray } = useContext(LinerContext)
 
   const [svgPos, setSvgPos] = useState<CoordArray>(pos.map(toSvgBasis))
+  useEffect(() => {
+    setSvgPos(pos.map(toSvgBasis))
+  }, [pos, toSvgBasis])
 
   const { subscribe, unsubscribe, start: startDrag } = useDraggable()
 
@@ -60,13 +63,13 @@ export const Polygon: React.FC<PolygonProps> = ({ pos, onChangePos }) => {
      */
     const updatePosition: DraggableHandler = (
       { name, vector: [tx, ty] },
-      ended
+      ended,
     ) => {
       const newSvgPos: CoordArray =
         name === 'g'
           ? clampCoordArray(initialSvgPos.map(([x, y]) => [x + tx, y + ty]))
           : initialSvgPos.map(([x, y], index) =>
-              name === `p${index}` ? clampCoord([x + tx, y + ty]) : [x, y]
+              name === `p${index}` ? clampCoord([x + tx, y + ty]) : [x, y],
             )
 
       if (ended) {
@@ -84,7 +87,7 @@ export const Polygon: React.FC<PolygonProps> = ({ pos, onChangePos }) => {
     return () => {
       unsubscribe()
     }
-  }, [pos])
+  }, [pos, toSvgBasis, toUserBasis])
 
   return (
     <g name="g" onPointerDown={startDrag}>

--- a/example/components/Text.tsx
+++ b/example/components/Text.tsx
@@ -56,7 +56,7 @@ export const Text: React.FC<TextProps> = ({
     return () => {
       unsubscribe()
     }
-  }, [userX, userY])
+  }, [userX, userY, toUserBasis])
 
   const [x, y] = toSvgBasis([userX, userY])
 

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -1,0 +1,8 @@
+import { ResizeObserver } from '@juggle/resize-observer'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/interface-name-prefix
+  interface Window {
+    readonly ResizeObserver: typeof ResizeObserver
+  }
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "react": ">= 16.8.2 < 17",
     "react-dom": ">= 16.8.2 < 17"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@juggle/resize-observer": "3.1.3"
+  },
   "devDependencies": {
     "@babel/cli": "7.8.4",
     "@babel/core": "7.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,6 +1008,11 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
+"@juggle/resize-observer@3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.1.3.tgz#d7373eb9a1afc371342b8cf1a07e34368f3d65d7"
+  integrity sha512-y7qc6SzZBlSpx8hEDfV0S9Cx6goROX/vBhS2Ru1Q78Jp1FlCMbxp7UcAN90rLgB3X8DSMBgDFxcmoG/VfdAhFA==
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
Instead of requiring the user to specifically set width and height,
we compute it from the SVG elements size. The use can control this
through CSS on the SVG element (via className, or styled components).

There is still an optional initialWidth/initialHeight which will be
used for initial rendering.

This also means that components must be aware that the `toSvgBasis`
and `toUserBasis` functions can change.

BREAKING:
 - `onReady` no longer passes visibleArea, but an object with
   visibleArea one of the properties
 - `width` and `height` properties removed from `Foundation`,
   you can still set the size for the <svg> element via CSS
   (if auto size does not work for you).