### PR TITLE
fix: resize observer does not track SVG layout

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -51,8 +51,8 @@ const App: React.FC = () => {
       <Foundation
         userBasis={USER_BASIS}
         style={{
-          width: '640px',
-          height: '480px',
+          width: '80vw',
+          height: '80vh',
           border: '1px solid deepskyblue',
         }}
       >

--- a/example/index.css
+++ b/example/index.css
@@ -5,5 +5,7 @@ body {
 }
 
 .main {
-  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/lib/Foundation.tsx
+++ b/lib/Foundation.tsx
@@ -130,7 +130,7 @@ interface TransformData {
   readonly height: number
 }
 
-export interface FoundationProps extends React.SVGProps<SVGSVGElement> {
+export interface FoundationProps extends React.Props<HTMLDivElement> {
   /**
    * Width of the visible area in pixels
    */
@@ -174,7 +174,7 @@ export interface FoundationProps extends React.SVGProps<SVGSVGElement> {
 }
 
 export const Foundation = React.forwardRef<
-  SVGSVGElement,
+  HTMLDivElement,
   React.PropsWithChildren<FoundationProps>
 >(
   (
@@ -186,7 +186,7 @@ export const Foundation = React.forwardRef<
       onReady,
       className,
       children,
-      ...svgProps
+      ...externalProps
     },
     ref,
   ) => {
@@ -253,8 +253,8 @@ export const Foundation = React.forwardRef<
     /**
      * Keep track of the SVG element (both internally and externally forwarded).
      */
-    const internalRef = useRef<SVGSVGElement | null>(null)
-    const callbackRef = useCallback((node: SVGSVGElement | null) => {
+    const internalRef = useRef<HTMLDivElement | null>(null)
+    const callbackRef = useCallback((node: HTMLDivElement | null) => {
       // Set the external forwarded ref if present
       if (ref !== null) {
         if (typeof ref === 'function') {
@@ -296,24 +296,21 @@ export const Foundation = React.forwardRef<
      */
 
     return (
-      <svg
-        className={className}
-        touch-action="none"
-        ref={callbackRef}
-        {...svgProps}
-      >
-        {toSvgBasis !== undefined && toUserBasis !== undefined ? (
-          <FoundationContext.Provider
-            value={{
-              userBasis,
-              toSvgBasis,
-              toUserBasis,
-            }}
-          >
-            {children}
-          </FoundationContext.Provider>
-        ) : null}
-      </svg>
+      <div ref={callbackRef} className={className} {...externalProps}>
+        <svg width={width} height={height}>
+          {toSvgBasis !== undefined && toUserBasis !== undefined ? (
+            <FoundationContext.Provider
+              value={{
+                userBasis,
+                toSvgBasis,
+                toUserBasis,
+              }}
+            >
+              {children}
+            </FoundationContext.Provider>
+          ) : null}
+        </svg>
+      </div>
     )
   },
 )


### PR DESCRIPTION
Resize observer doesn't work on an `svg` element, so `Foundation` is wrapped in a `div` instead.

![svg-resize](https://user-images.githubusercontent.com/1499470/83627591-75030b80-a597-11ea-97b8-bd9da3c95cdd.gif)
