### PR TITLE
fix: do not render when width/height <= 0

### DIFF
--- a/lib/Foundation.tsx
+++ b/lib/Foundation.tsx
@@ -198,7 +198,12 @@ export const Foundation = React.forwardRef<
      * user coordinates to SVG coordinates and back.
      */
     const { toSvgBasis, toUserBasis } = useMemo(() => {
-      if (width === undefined || height === undefined) {
+      if (
+        width === undefined ||
+        width <= 0 ||
+        height === undefined ||
+        height <= 0
+      ) {
         return {}
       }
       // Set up basis transform from user to svg space:


### PR DESCRIPTION
To avoid situations with singular matrices,
exclude widths and/or heights that are 0.
For completeness and simplicity, negative
values are excluded as well.

So, any invalid width/height will result in
nothing being rendered at all (since the
transformation functions are undefined).