### PR TITLE
fix: remove unnecessary context value changes

### DIFF
--- a/lib/Foundation.tsx
+++ b/lib/Foundation.tsx
@@ -296,6 +296,18 @@ export const Foundation = React.forwardRef<
       return () => observer.disconnect()
     }, [])
 
+    const contextValue: FoundationContextProps | undefined = useMemo(
+      () =>
+        toSvgBasis !== undefined && toUserBasis !== undefined
+          ? {
+              userBasis,
+              toSvgBasis,
+              toUserBasis,
+            }
+          : undefined,
+      [userBasis, toSvgBasis, toUserBasis],
+    )
+
     /**
      * Render SVG drawing area.
      */
@@ -303,14 +315,8 @@ export const Foundation = React.forwardRef<
     return (
       <div ref={callbackRef} className={className} {...externalProps}>
         <svg width={width} height={height}>
-          {toSvgBasis !== undefined && toUserBasis !== undefined ? (
-            <FoundationContext.Provider
-              value={{
-                userBasis,
-                toSvgBasis,
-                toUserBasis,
-              }}
-            >
+          {contextValue !== undefined ? (
+            <FoundationContext.Provider value={contextValue}>
               {children}
             </FoundationContext.Provider>
           ) : null}

--- a/lib/Liner.tsx
+++ b/lib/Liner.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react'
+import React, { useContext, useCallback, useMemo } from 'react'
 
 import { FoundationContext, Area, BBox } from './Foundation'
 import { bbox, Coord, CoordArray } from './utils/geometry'
@@ -35,9 +35,11 @@ export interface LinerProps {
 export const Liner: React.FC<LinerProps> = ({ area, children }) => {
   const { userBasis, toSvgBasis } = useContext(FoundationContext)
 
-  const areaUserBasis = area ?? userBasis
-  const areaSvgBasis = areaUserBasis.map(toSvgBasis)
-  const areaBBox = bbox(areaSvgBasis)
+  const areaBBox = useMemo(() => {
+    const areaUserBasis = area ?? userBasis
+    const areaSvgBasis = areaUserBasis.map(toSvgBasis)
+    return bbox(areaSvgBasis)
+  }, [area, userBasis, toSvgBasis, bbox])
 
   // Function that limits a point within the area's bounding box
   const clampCoord = useCallback(
@@ -80,15 +82,18 @@ export const Liner: React.FC<LinerProps> = ({ area, children }) => {
     [areaBBox],
   )
 
+  const contextValue: LinerContextProps = useMemo(
+    () => ({
+      areaBBox,
+      clampCoord,
+      clampCoordArray,
+      clampBBox,
+    }),
+    [areaBBox, clampCoord, clampCoordArray, clampBBox],
+  )
+
   return (
-    <LinerContext.Provider
-      value={{
-        areaBBox,
-        clampCoord,
-        clampCoordArray,
-        clampBBox,
-      }}
-    >
+    <LinerContext.Provider value={contextValue}>
       {children}
     </LinerContext.Provider>
   )


### PR DESCRIPTION
Especially Liner, but also Foundation, sent out a new context value
each time the component was rendered.

This adds a useMemo around areaBBox so that the value and functions in
the Liner context don't change every render. It also adds useMemo for
the actual context value for both Linder and Foundation.