### PR TITLE
feat: enable click through in Foundation

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -1,4 +1,5 @@
 import { useState, FC } from 'react'
+import styled from 'styled-components'
 
 import {
   Foundation,
@@ -26,9 +27,17 @@ const MIDDLE_AREA: Area = [
   [0.5, -0.5], // bottom right coordinate
 ]
 
+const Layers = styled.div`
+  position: relative;
+  width: 80vw;
+  height: 80vh;
+  border: 1px solid deepskyblue;
+`
+
 const App: FC = () => {
   const [textPos1, setTextPos1] = useState<Coord>([-1, 0.8])
   const [textPos2, setTextPos2] = useState<Coord>([-0.4, -0.5])
+  const [textPos3, setTextPos3] = useState<Coord>([-0.5, 0])
   const [polygonPos, setPolygonPos] = useState<CoordArray>([
     [0.6, 0.1],
     [0.8, 0.2],
@@ -47,40 +56,64 @@ const App: FC = () => {
       <p>
         To get started, edit <code>src/App.tsx</code> and save to reload.
       </p>
-
-      <Foundation
-        userBasis={USER_BASIS}
-        style={{
-          width: '80vw',
-          height: '80vh',
-          border: '1px solid deepskyblue',
-        }}
-      >
-        <Text x={textPos1[0]} y={textPos1[1]} onChangePos={setTextPos1}>
-          I can be dragged outside of the visible area
-        </Text>
-        <Liner>
-          <Text x={textPos2[0]} y={textPos2[1]} onChangePos={setTextPos2}>
-            I can be dragged but I am limited to the visible area
+      <Layers>
+        <Foundation
+          userBasis={USER_BASIS}
+          style={{
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            left: '0',
+            top: '0',
+            right: '0',
+            bottom: '0',
+          }}
+        >
+          <Text x={textPos1[0]} y={textPos1[1]} onChangePos={setTextPos1}>
+            I can be dragged outside of the visible area
           </Text>
-          <Polygon pos={polygonPos} onChangePos={setPolygonPos} />
-          <Circle pos={circle1Pos} r={5} />
-          <DraggableCircle
-            pos={circle2Pos}
-            onChangePos={setCircle2Pos}
-            r={10}
-          />
-
-          <Liner area={MIDDLE_AREA}>
-            <FastDraggableCircle
-              id={'5'}
-              pos={circle3Pos}
-              onChangePos={setCircle3Pos}
-              r={20}
+          <Liner>
+            <Text x={textPos2[0]} y={textPos2[1]} onChangePos={setTextPos2}>
+              I can be dragged but I am limited to the visible area
+            </Text>
+            <Polygon pos={polygonPos} onChangePos={setPolygonPos} />
+            <Circle pos={circle1Pos} r={5} />
+            <DraggableCircle
+              pos={circle2Pos}
+              onChangePos={setCircle2Pos}
+              r={10}
             />
+
+            <Liner area={MIDDLE_AREA}>
+              <FastDraggableCircle
+                id={'5'}
+                pos={circle3Pos}
+                onChangePos={setCircle3Pos}
+                r={20}
+              />
+            </Liner>
           </Liner>
-        </Liner>
-      </Foundation>
+        </Foundation>
+
+        <Foundation
+          userBasis={USER_BASIS}
+          style={{
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            left: '0',
+            top: '0',
+            right: '0',
+            bottom: '0',
+          }}
+          clickThrough={true}
+        >
+          <Text x={textPos3[0]} y={textPos3[1]} onChangePos={setTextPos3}>
+            I am in another Foundation above everything else and you can still
+            interact with the svg's below me
+          </Text>
+        </Foundation>
+      </Layers>
     </div>
   )
 }

--- a/lib/Foundation.tsx
+++ b/lib/Foundation.tsx
@@ -11,12 +11,27 @@ import {
   CSSProperties,
   PropsWithChildren,
 } from 'react'
+import styled, { css } from 'styled-components'
 
 import { multiply, inverse, apply, Matrix } from './utils/affine'
 import { Coord } from './utils/geometry'
 
 type BaseElement = HTMLDivElement
 type BaseProps = HTMLAttributes<BaseElement>
+
+const Container = styled.div<{ readonly clickThrough: boolean }>`
+  ${({ clickThrough }) =>
+    clickThrough
+      ? css`
+          pointer-events: none;
+          & > svg > * {
+            pointer-events: initial;
+          }
+        `
+      : css`
+          pointer-events: initial;
+        `}
+`
 
 // Prototype of an Svg implementation with basis transform capabilities.
 
@@ -179,6 +194,10 @@ export interface FoundationProps extends BaseProps {
    * Classname for the <svg> container
    */
   readonly className?: string
+  /**
+   * Should Foundation respond to pointer events
+   */
+  readonly clickThrough?: boolean
 }
 
 export const Foundation = forwardRef<
@@ -193,6 +212,7 @@ export const Foundation = forwardRef<
       transformationMatrix,
       onReady,
       className,
+      clickThrough = false,
       children,
       ...externalProps
     },
@@ -323,9 +343,13 @@ export const Foundation = forwardRef<
     /**
      * Render SVG drawing area.
      */
-
     return (
-      <div ref={callbackRef} className={className} {...externalProps}>
+      <Container
+        ref={callbackRef}
+        clickThrough={clickThrough}
+        className={className}
+        {...externalProps}
+      >
         <svg width={width} height={height}>
           {contextValue !== undefined ? (
             <FoundationContext.Provider value={contextValue}>
@@ -333,7 +357,7 @@ export const Foundation = forwardRef<
             </FoundationContext.Provider>
           ) : null}
         </svg>
-      </div>
+      </Container>
     )
   },
 )


### PR DESCRIPTION
### Describe your changes
Adds a clickThrough prop that will remove pointer-events
except for nodes wrapped in the svg.

### Issue ticket number and link

- Fixes #56 

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
